### PR TITLE
#VULCAN-282/Fixed the Word overflow in expand cell

### DIFF
--- a/src/component/misc/DataGridExpandedRenderer.tsx
+++ b/src/component/misc/DataGridExpandedRenderer.tsx
@@ -95,7 +95,7 @@ const GridCellExpand = React.memo((props: GridCellExpandProps) => {
       {showPopper && (
         <Popper open={showFullCell && anchorEl !== null} anchorEl={anchorEl} style={{ width, marginLeft: -17 }}>
           <Paper elevation={1} style={{ minHeight: wrapper.current!.offsetHeight - 3 }}>
-            <Typography variant='body2' style={{ padding: 8, whiteSpace: 'pre-line' }}>
+            <Typography variant='body2' style={{ padding: 8, whiteSpace: 'normal', wordBreak: 'break-word' }}>
               {value}
             </Typography>
           </Paper>


### PR DESCRIPTION
Fixed: Table cell overlay in case of too long words has too small background box